### PR TITLE
Fix for working with other async tasks

### DIFF
--- a/tasks/casperjs.js
+++ b/tasks/casperjs.js
@@ -5,18 +5,22 @@ module.exports = function( grunt ) {
 
         // Tell grunt this task is asynchronous.
         var done = this.async(),
-            files = grunt.file.expandFiles(this.file.src);
+            files = grunt.file.expandFiles(this.file.src),
+            filepaths = [];
 
         grunt.file.expandFiles(this.file.src).forEach(function(filepath) {
+            filepaths.push(filepath);
+        });
+
+        grunt.utils.async.forEachSeries(filepaths, function runCasper(filepath, callback) {
             grunt.helper('casperjs', filepath, function(err){
                 if (err) {
                     grunt.warn(err);
-                    done(false);
-                } else {
-                    done();
                 }
+                callback();
             });
-        });
+        }, done);
+
     });
 
     grunt.registerHelper('casperjs', function(filepath, callback) {


### PR DESCRIPTION
There was a missing callback on success, so this would hang indefinitely when called with another async task. For example:

grunt server casperjs

I need to do the above for my particular project because I run tests that need the http:// protocol instead of the file:// 

Before:
grunt server casperjs #hangs indefinitely

After:
grunt server casperjs #finishes correctly
