### PR TITLE
Do not break other npm packages.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
       "url": "https://github.com/ronaldlokers/grunt-casperjs/blob/master/LICENSE-MIT"
     }
   ],
-  "main": "grunt.js",
+  "main": "tasks/casperjs.js",
   "bin": "bin/grunt-casperjs",
   "engines": {
     "node": "*"


### PR DESCRIPTION
Grunt-casperjs currently breaks other npm packages in some cases.

The simple line change fixes this.
