### PR TITLE
Add new 'engine' option of Casperjs

### DIFF
--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -23,6 +23,10 @@ exports.init = function(grunt) {
     if (options.logLevel) {
       command += ' --log-level=' + options.logLevel;
     }
+    
+    if (options.engine) {
+      command += ' --engine=' + options.engine;
+    }
 
     if (options.pre) {
       command += ' --pre=' + options.pre.join(',');


### PR DESCRIPTION
A new options has been introduced in casper 1.1.
See http://docs.casperjs.org/en/latest/cli.html#casperjs-native-options

Casper can run over Slimerjs instead of Phantomjs, a headless browser builds on top of Gecko
See http://slimerjs.org/
