### PR TITLE
Allow passing the --ignore-ssl-errors option as ignoreSslErrors

### DIFF
--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -60,6 +60,10 @@ exports.init = function(grunt) {
       command += ' --cookies-file='+ options.cookiesFile;
     }
 
+    if (options.ignoreSslErrors) {
+      command += ' --ignore-ssl-errors='+ options.ignoreSslErrors;
+    }
+
 
     command += " " + filepath;
 


### PR DESCRIPTION
There is currently no way to pass the --ignore-ssl-errors option to casperjs.

This has been requested in issue #15.
