### PR TITLE
Allow passing the --cookies-file option as cookiesFile

### DIFF
--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -56,6 +56,9 @@ exports.init = function(grunt) {
       command += ' --ssl-protocol='+ options.sslProtocol;
     }
 
+    if (options.cookiesFile) {
+      command += ' --cookies-file='+ options.cookiesFile;
+    }
 
 
     command += " " + filepath;


### PR DESCRIPTION
There is currently no way to pass the --cookies-file option to casperjs. This pull requests adds an option to provide the value for that option.
