### PR TITLE
If user has casperjs installed we make symlink to installed one

### DIFF
--- a/install.js
+++ b/install.js
@@ -18,12 +18,13 @@ var downloadUrl = 'https://github.com/n1k0/casperjs/archive/1.0.3.zip'
 
 
 function isCasperInstalled(notInstalledCallback) {
-    cp.exec("casperjs --version", function(error, stdout, stderr) {
-        if ( error || stderr || !stdout.length ) {
+    cp.exec("which casperjs", function(error, stdout, stderr) {
+        if ( error ) {
             console.log("Casperjs not installed.  Installing.");
             notInstalledCallback();
         } else {
             console.log("Casperjs already installed: " + stdout);
+            fs.symlinkSync(stdout.replace(/\s/, ''), './casperjs');
         }
     });
 }
@@ -38,7 +39,8 @@ function unzipTheZippedFile() {
 
     if (process.platform != 'win32') {
         var pathToCommand = path.join(libPath, 'casperjs-1.0.3', 'bin', 'casperjs');
-        var stat = fs.statSync(pathToCommand)
+        fs.symlinkSync(pathToCommand, './casperjs');
+        var stat = fs.statSync(pathToCommand);
         if (!(stat.mode & 64)) {
             fs.chmodSync(pathToCommand, '755')
         }

--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -5,8 +5,7 @@ exports.init = function(grunt) {
 
   exports.casperjs = function(filepath, options, callback) {
 
-    var capserPath = path.join(__dirname, '..', '..', 'lib', 'casperjs', 'casperjs-1.0.3', 'bin'),
-        command = path.join(capserPath, 'casperjs') + ' test',
+    var command = path.join(__dirname, '..', '..', 'casperjs') + ' test',
         exec = require('child_process').exec,
         phantomBinPath = require('phantomjs').path;
 
@@ -27,7 +26,7 @@ exports.init = function(grunt) {
     if (options.logLevel) {
       command += ' --log-level=' + options.logLevel;
     }
-    
+
     if (options.engine) {
       command += ' --engine=' + options.engine;
     }
@@ -39,7 +38,7 @@ exports.init = function(grunt) {
     if (options.post) {
       command += ' --post=' + options.post.join(',');
     }
-	
+
 	  if (options.webSecurity === false) {
       command += ' --web-security=no';
     }


### PR DESCRIPTION
I had casperjs installed with brew before I installed grunt-casperjs. So there is currently check for casperjs existence, but later in the code tries to run casperjs from the place where it was presumably downloaded to. So I create symlink in both cases (when I have own casperjs and when we download one)
