### PR TITLE
Use latest version of phantomjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "phantomjs": "1.9.1-0",
+    "phantomjs": "~1.9.1",
     "rimraf": "~2.1.4",
     "adm-zip": "~0.4.3"
   },


### PR DESCRIPTION
Is there any reason why the phantomjs is pinned to an older version (`1.9.1-0`)? I have tested it with the latest version (as per this patch) and it all seems to work fine.

PhantomJS `1.9.1-9` introduces a fix I contributed which prevents errors upon running `npm install` where multiple package transitively depend on the phantomjs package. For instance, if both grunt-casperjs and karma-phantomjs-launcher are present, the installation would randomly fail due to a race condition bug.
