### PR TITLE
Fixing env-vars dump

### DIFF
--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -86,12 +86,10 @@ exports.init = function(grunt) {
         callback();
       }
     }
+    
+    process.env["PHANTOMJS_EXECUTABLE"] = phantomBinPath;
 
-    exec(command, {
-        env: {
-            "PHANTOMJS_EXECUTABLE": phantomBinPath
-        }
-    }, puts);
+    exec(command, puts);
 
   };
 


### PR DESCRIPTION
The way that `phantomBinPath` was being passed to `exec()` was cleaning out the other parameters.

Now, we should append `phantomBinPath` to the existent set of vars and don't care about it anymore.

Fixes #24
