### PR TITLE
Fix symlinking of already installed version

### DIFF
--- a/install.js
+++ b/install.js
@@ -21,9 +21,9 @@ function isCasperInstalled(notInstalledCallback) {
     findInstalledCasper(function(path, version) {
         if (path) {
             console.log("Use already installed Casperjs.");
-            console.log("  Version: " + stdout);
-            console.log("  Path:    " + pathStdout);
-            fs.symlinkSync(pathStdout.replace(/\s/, ''), './casperjs');
+            console.log("  Version: " + version);
+            console.log("  Path:    " + path);
+            fs.symlinkSync(path, './casperjs');
         } else {
             console.log("Casperjs not installed.  Installing.");
             notInstalledCallback();


### PR DESCRIPTION
A [recent change](https://github.com/ronaldlokers/grunt-casperjs/commit/4666f72b2ed06d5aa6381d913ad038c9ab2bbda2) for windows compatibility broke the support for using an already installed CasperJS altogether, by causing the casperjs symlink at the root of the module to point to an imaginary file named after the installed version, e.g.

```
$ ls -l node_modules/grunt-casperjs/casperjs 
lrwxrwxrwx 1 seb seb 9 Oct  1 16:46 node_modules/grunt-casperjs/casperjs -> 1.1.0-DEV
```

This patch fixes the problem, while still looking up the version for logging. However this is likely not working on Windows, as the prior change hinted that `which` does not work on Windows.

If anyone can think of a better way to look up the path of an installed program in an OS-agnostic (i.e. Windows-friendly) way, please shout and I will adapt my pull request. I'm forced to use this for now as I'm otherwise unable to run grunt-casperjs at all anymore...
