### PR TITLE
Better support for installation from paths with spaces

### DIFF
--- a/install.js
+++ b/install.js
@@ -24,9 +24,9 @@ function isCasperInstalled(notInstalledCallback) {
             console.log("Casperjs not installed.  Installing.");
             notInstalledCallback();
         } else {
-            var casperVersion = stdout.replace(/\s/, '');
-            cp.exec("casperjs " + path.join(__dirname, "tasks", "lib", "casperjs-path.js"), function(error, stdout, stderr) {
-                var casperPath = stdout.replace(/\s/, '');
+            var casperVersion = stdout.replace(/^\s+|\s+$/g,'');
+            cp.exec("casperjs '" + path.join(__dirname, "tasks", "lib", "casperjs-path.js") + "'", function(error, stdout, stderr) {
+                var casperPath = stdout.replace(/^\s+|\s+$/g,'');
                 console.log("Casperjs version " + casperVersion + " installed at " + casperPath);
                 var casperExecutable = path.join(casperPath, "bin", "casperjs");
                 fs.symlinkSync(casperExecutable, './casperjs');


### PR DESCRIPTION
Better support for installation from paths with spaces. Corrected issues with path trimming regex and surround path parameter for casperjs with single quotes.

Resolves ronaldlokers/grunt-casperjs#29
