### PR TITLE
CasperJS options can be passed in via grunt task. 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,12 +24,10 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     casperjs: {
-      files: ['test/casperjs.js'],
       options: {
-        custom: {
-          customParam: 'bar'
-        }
-      }
+        casperjsOptions: ["--foo=bar"]
+      },
+      files: ['test/casperjs.js']
     },
 
   });

--- a/README.md
+++ b/README.md
@@ -70,28 +70,16 @@ casperjs: {
 }
 ```
 
-#### Custom options
+#### CasperJS Options
 
-CasperJS supports custom options passed via flags on the command line. These can be passed through to your tests via the ```options.custom``` object in your Grunt config.
-
+CasperJS options (including user defined ones) can be passed in using 'casperjsOptions' in the options object
 ```javascript
 casperjs: {
   options: {
-    custom: {
-      param: 'value'
-    }
-  }
+    casperjsOptions: ['--foo=bar', '--no-colors']
+  },
+  files: ['tests/casperjs/**/*.js']
 }
-```
-
-To make use of your custom parameters in your test file, use ```casper.cli.get()```.
-
-```javascript
-var casper = require('casper').create();
-
-casper.start('http://www.google.nl/', function() {
-  this.test.assertEquals(casper.cli.get('param'), 'value');
-});
 ```
 
 #### Install script and CasperJS version
@@ -106,6 +94,7 @@ In lieu of a formal styleguide, take care to maintain the existing coding style.
 
 
 ## CHANGELOG
+* 1.4.0 Options can be passed into CasperJS. Any option.
 * 1.3.0 Bump to using the latest version of CasperJs
 * 1.2.1 CasperJS installations in path will be used
 * 1.2.0 Cleaner fix for installing grunt

--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -10,68 +10,8 @@ exports.init = function(grunt) {
         spawn = require('child_process').spawn,
         phantomBinPath = require('phantomjs').path;
 
-    // Add options documented in the following web site:
-    //   http://casperjs.org/testing.html
-    if (options.xunit) {
-      args.push('--xunit=' + options.xunit);
-    }
-
-    if (options.direct) {
-      args.push('--direct');
-    }
-
-    if (options.includes) {
-      args.push('--includes=' + options.includes.join(','));
-    }
-
-    if (options.logLevel) {
-      args.push('--log-level=' + options.logLevel);
-    }
-
-    if (options.engine) {
-      args.push('--engine=' + options.engine);
-    }
-
-    if (options.pre) {
-      args.push('--pre=' + options.pre.join(','));
-    }
-
-    if (options.post) {
-      args.push('--post=' + options.post.join(','));
-    }
-
-    if (options.webSecurity === false) {
-      args.push('--web-security=no');
-    }
-
-    if (options.proxy) {
-      args.push('--proxy='+ options.proxy);
-    }
-
-    if (options.proxyType) {
-      args.push('--proxy-type='+ options.proxyType);
-    }
-
-    if (options.outputEncoding) {
-      args.push('--output-encoding='+ options.outputEncoding);
-    }
-
-    if (options.sslProtocol) {
-      args.push('--ssl-protocol='+ options.sslProtocol);
-    }
-
-    if (options.cookiesFile) {
-      args.push('--cookies-file='+ options.cookiesFile);
-    }
-
-    if (options.ignoreSslErrors) {
-      args.push('--ignore-ssl-errors=yes');
-    }
-
-    if (options.custom) {
-        for (option in options.custom) {
-            args.push('--' + option + '=' + options.custom[option]);
-        }
+    if (options.casperjsOptions && options.casperjsOptions.length > 0) {
+        args = args.concat(options.casperjsOptions);
     }
 
     args.push(filepath);

--- a/test/casperjs.js
+++ b/test/casperjs.js
@@ -1,6 +1,7 @@
 var casper = require('casper').create();
 
 casper.start('http://www.google.nl/', function() {
+    this.test.assertEquals(casper.cli.get('foo'), 'bar', "options were passed in successfully")
     this.test.assertTitle('Google', 'google homepage title is the one expected');
     this.test.assertExists('form[action="/search"]', 'main form is found');
     this.fill('form[action="/search"]', {
@@ -14,7 +15,6 @@ casper.then(function() {
     this.test.assertEval(function() {
         return __utils__.findAll('h3.r').length >= 10;
     }, 'google search for "foo" retrieves 10 or more results');
-    this.test.assertEquals(casper.cli.get('customParam'), 'bar', 'custom parameter specified in Gruntfile has been fetched');
 });
 
 casper.run(function() {


### PR DESCRIPTION
CasperJS options can be passed in via grunt task. There are no restrictions now as to which options can be used.

This allows for more flexibility and less less maintenance by allowing user defined options and not restricting the options to hard coded set.

I've updated the README as well. 

**Note**: This breaks how options were previously passed in.

Resolves the issue raised in ronaldlokers/grunt-casperjs#33
