### PR TITLE
Locking Casper to a specific tag instead of master

### DIFF
--- a/install.js
+++ b/install.js
@@ -13,7 +13,7 @@ fs.existsSync = fs.existsSync || path.existsSync
 
 var libPath = path.join(__dirname, 'lib', 'casperjs')
 var tmpPath = path.join(__dirname, 'tmp')
-var version = 'master'
+var version = '1.1-beta2'
 var downloadUrl = 'https://github.com/n1k0/casperjs/archive/' + version + '.zip'
 
 


### PR DESCRIPTION
I'd like to propose installing a tagged version of Casper instead of using whatever is on master. I'm having difficulty ensuring my Grunt task will work consistently between team members since master is a moving target. I'd prefer not to depend on a global Casper install to solve this. Thanks!
