### PR TITLE
Changed casperjs to ~1.1 because there is no 1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "phantomjs": "~1.9.1",
-    "casperjs": "~1.1.0"
+    "casperjs": "~1.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
https://github.com/n1k0/casperjs/tags
