### PR TITLE
added option to specify engines for executing tests, fixed casper integr...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,10 +6,10 @@
  * Licensed under the MIT license.
  */
 
-'use strict';
+
 
 module.exports = function(grunt) {
-
+  'use strict';
   // Project configuration.
   grunt.initConfig({
     jshint: {
@@ -18,17 +18,21 @@ module.exports = function(grunt) {
         'tasks/*.js'
       ],
       options: {
-        jshintrc: '.jshintrc',
-      },
+        jshintrc: '.jshintrc'
+      }
     },
 
     // Configuration to be run (and then tested).
     casperjs: {
       options: {
-        casperjsOptions: ["--foo=bar"]
+        casperjsOptions: ["--foo=bar"],
+        engines: {
+          phantomjs: true,
+          slimerjs: false
+        }
       },
       files: ['test/casperjs.js']
-    },
+    }
 
   });
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
   },
   "dependencies": {
     "phantomjs": "~1.9.1",
-    "casperjs": "~1.1"
+    "slimerjs": "~0.9.2",
+    "casperjs": "1.1.0-beta3",
+    "kew": "0.4.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",

--- a/tasks/casperjs.js
+++ b/tasks/casperjs.js
@@ -6,10 +6,10 @@
  * Licensed under the MIT license.
  */
 
-'use strict';
+
 
 module.exports = function(grunt) {
-
+  'use strict';
   var casperjs = require('./lib/casperjs').init(grunt).casperjs;
 
   grunt.registerMultiTask('casperjs', 'Run CasperJs tests.', function() {

--- a/test/casperjs.js
+++ b/test/casperjs.js
@@ -1,22 +1,50 @@
-var casper = require('casper').create();
+/*jshint strict:false*/
+/*global CasperError, console, phantom, require, casper*/
 
-casper.start('http://www.google.nl/', function() {
-    this.test.assertEquals(casper.cli.get('foo'), 'bar', "options were passed in successfully")
-    this.test.assertTitle('Google', 'google homepage title is the one expected');
-    this.test.assertExists('form[action="/search"]', 'main form is found');
-    this.fill('form[action="/search"]', {
-        q: 'foo'
-    }, true);
-});
+casper.test.begin('default test', 4, function(test) {
+    casper.start('http://www.google.com/');
 
-casper.then(function() {
-    this.test.assertTitle('foo - Google zoeken', 'google title is ok');
-    this.test.assertUrlMatch(/q=foo/, 'search term has been submitted');
-    this.test.assertEval(function() {
-        return __utils__.findAll('h3.r').length >= 10;
-    }, 'google search for "foo" retrieves 10 or more results');
-});
+    casper.waitFor(function() {
+        return this.evaluate(function() {
+            return document.title === 'Google';
+        });
+    }, function() {
+        test.pass('google homepage title is the one expected');
+    }, function() {
+        test.fail('Failed finding title');
+    });
 
-casper.run(function() {
-    this.test.renderResults(true);
+    if (casper.cli.get('foo') === 'bar') {
+        test.pass('options were passed in successfully');
+    } else {
+        test.fail('options were not passed in successfully');
+    }
+
+    casper.waitFor(function() {
+        return this.evaluate(function() {
+            return document.querySelectorAll('form[action="/search"]').length === 1;
+        });
+    }, function() {
+        test.pass('main form is found');
+    }, function() {
+        test.fail('Failed finding form');
+    });
+
+    casper.then(function () {
+        this.fillSelectors('form[action="/search"]', { 'input[name="q"]': 'foo' }, true);
+    });
+
+    casper.waitFor(function() {
+        return this.evaluate(function() {
+            return document.title === 'foo - Google Search';
+        });
+    }, function() {
+        test.pass('google search title is the one expected');
+    }, function() {
+        test.fail('Failed finding search title');
+    });
+
+    casper.run(function() {
+        test.done();
+    });
 });


### PR DESCRIPTION
I hope you find this pull request useful! I added a new "engines" option to the options field in the casperjs grunt task. This lets you specify either PhantomJS, SlimerJS, or both as targets. Leaving this option out will still execute the tests using PhantomJS as they did before, so it should be backwards compatible. I did add the engines option to the plugin's Gruntfile.js just to show the option, it isn't necessary, but I thought it was useful to include.

I also fixed the integration tests, they were still using options from the previous version of casperjs and would not work correctly. You should be able to run grunt from the command line now and see the test execute.

Let me know if anything doesn't look right in this PR and I can update it.
