### PR TITLE
Proper version reference for casperjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "phantomjs": "~1.9.1",
-    "casperjs": "~1.1"
+    "casperjs": "1.1.0-beta3"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.1.1",


### PR DESCRIPTION
Since `~1.1` means “stable versions only” in npm 2.x, package installation is failing as there’s no stable 1.1 version yet, only beta. Sholud fix #66.
