### PR TITLE
UPGRADE all dependencies to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,17 +41,17 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "phantomjs": "~1.9.1",
-    "casperjs": "1.1.0-beta3"
+    "phantomjs-prebuilt": "~2.1.4",
+    "casperjs": "1.1.1"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-clean": "~0.4.0",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt": "~0.4.0"
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0",
+    "grunt": "~1.0.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": ">=0.4.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/lib/casperjs.js
+++ b/tasks/lib/casperjs.js
@@ -18,7 +18,7 @@ exports.init = function(grunt) {
     }
     var args = ['test'],
         spawn = require('child_process').spawn,
-        phantomBinPath = require('phantomjs').path;
+        phantomBinPath = require('phantomjs-prebuilt').path;
 
     if (options.casperjsOptions && options.casperjsOptions.length > 0) {
         args = args.concat(options.casperjsOptions);

--- a/test/casperjs.js
+++ b/test/casperjs.js
@@ -1,4 +1,3 @@
-var casper = require('casper').create();
 
 casper.start('http://www.google.nl/', function() {
     this.test.assertEquals(casper.cli.get('foo'), 'bar', "options were passed in successfully")
@@ -15,6 +14,10 @@ casper.then(function() {
     this.test.assertEval(function() {
         return __utils__.findAll('h3.r').length >= 10;
     }, 'google search for "foo" retrieves 10 or more results');
+});
+
+casper.then(function () {
+    this.test.done();
 });
 
 casper.run(function() {


### PR DESCRIPTION
This updates all dependencies to their latest version inclusing casperjs and phantomjs (renamed to phantomjs-prebuild) this fixes #72 and closes #77 and #76.